### PR TITLE
Add logging to agents and setup config

### DIFF
--- a/agents/chat_agent.py
+++ b/agents/chat_agent.py
@@ -3,14 +3,17 @@ from langgraph.types import Command
 from state.state import State, Message
 from config.model_config import llm
 from prompts_library import chat_prompt
+import logging
+
+logger = logging.getLogger(__name__)
 
 def chat_agent(state: State) -> Command[Literal["supervisor"]]:
-    print("*****************************Entered CHAT AGENT****************************************************")
+    logger.info("Entered CHAT AGENT")
     messages = [chat_prompt.SYSTEM_PROMPT] + [{"role": "user", "content": state.query}]
     response = llm.invoke(messages)
-    print(response.content)
+    logger.info(response.content)
     state.messages.append(Message(role="chat", content=response.content))
-    print("*****************************END CHAT AGENT****************************************************")
+    logger.info("END CHAT AGENT")
     return Command(
         goto="supervisor", 
         update={

--- a/agents/upsell_agent.py
+++ b/agents/upsell_agent.py
@@ -6,6 +6,9 @@ import json
 import os
 import re
 from config.model_config import llm
+import logging
+
+logger = logging.getLogger(__name__)
 
 # Load synthetic upsell data
 UPS_DATA_PATH = os.path.join(os.path.dirname(__file__), "../data/synthetic_upsell_data.json")
@@ -42,6 +45,8 @@ def upsell_recommendation_agent(state: State) -> Command[Literal["supervisor"]]:
         f"For customer ID **{selected['customer_id']}**, located in {selected['location']} (ZIP: {selected['zip']}), "
         f"we recommend our **{selected['recommended_upsell']}**. Reason: {selected['reason']}"
     )
+
+    logger.debug("Upsell recommendation selected: %s", selected)
 
     state.messages.append(Message(role="upsell", content=upsell_message))
 

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,12 @@
+import logging
+import os
+
+
+def setup_logging():
+    level_str = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_str, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    )
+

--- a/main.py
+++ b/main.py
@@ -1,5 +1,8 @@
 from fastapi import FastAPI
 from routers import chat_router
+from logging_config import setup_logging
+
+setup_logging()
 
 app = FastAPI()
 app.include_router(chat_router.router, tags=["Chat"])


### PR DESCRIPTION
## Summary
- configure global logging via LOG_LEVEL env var
- add logger usage in chat, address, upsell, and supervisor agents
- log upsell recommendations
- initialize logging in main

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c5a32eabc8322aa808dcc94c87a02